### PR TITLE
Support streamed files

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,6 @@ module.exports = function (dest, opts) {
 			return cb();
 		}
 
-		if (file.isStream()) {
-			this.emit('error', new gutil.PluginError('gulp-changed', 'Streaming not supported'));
-			return cb();
-		}
-
 		var newPath = path.join(dest, file.relative);
 
 		if (opts.extension) {


### PR DESCRIPTION
Hi! Is there actually a reason not to support streamed files here? 
The only reason I see for not supporting streamed files is when the file content it self is being altered in some way.

If the content-property of the vinyl file is a stream or not won't affect this plugin in any negative sense at all, rather opposite, as far as I can tell. If one uses non-buffered contents, it's likely that they are handling large files, and thus this plugin is even more useful. 

Maybe I'm missing something obvious here?
