### PR TITLE
Update "through2" dependency to match the current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-changed",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Only pass through changed files",
   "license": "MIT",
   "repository": "sindresorhus/gulp-changed",


### PR DESCRIPTION
Helps when [deduping](https://www.npmjs.org/doc/cli/npm-dedupe.html) projects using `gulp-changed`.
