### PR TITLE
Many-to-one matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,26 @@
 'use strict';
 
-var pluginName = 'gulp-changed';
-
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
 var gutil = require('gulp-util');
 var through = require('through2');
 
-// ignore missing file error
+/**
+ * Name of this gulp plugin.
+ *
+ * @type {string}
+ */
+var pluginName = 'gulp-changed';
+
+/**
+ * Evaluate error returned by node's file system methods, missing file error is ignored and the source file is pushed.
+ *
+ * @param {Stream} stream - Through stream object.
+ * @param {File} sourceFile - Vinyl file object.
+ * @param {null|Error} err - Possibly thrown error.
+ * @return {null|Error} The `err` argument.
+ */
 function fsOperationFailed(stream, sourceFile, err) {
 	if (err) {
 		if (err.code !== 'ENOENT') {
@@ -23,11 +35,25 @@ function fsOperationFailed(stream, sourceFile, err) {
 	return err;
 }
 
+/**
+ * Get the sha1 hex digest of a buffer.
+ *
+ * @param {Buffer} buf - The buffer to get the sha1 hex digest for.
+ * @return {string} The sha1 hex digest of the buffer.
+ */
 function sha1(buf) {
 	return crypto.createHash('sha1').update(buf).digest('hex');
 }
 
-// only push through files changed more recently than the destination files
+/**
+ * Compare last modified time of source and target and only push through files which changed.
+ *
+ * @param {Stream} stream - Through stream object.
+ * @param {Function} cb - Done callback.
+ * @param {File} sourceFile - Vinyl file object.
+ * @param {string} targetPath - Path of the target.
+ * @return {undefined}
+ */
 function compareLastModifiedTime(stream, cb, sourceFile, targetPath) {
 	fs.stat(targetPath, function (err, targetStat) {
 		if (!fsOperationFailed(stream, sourceFile, err)) {
@@ -40,7 +66,15 @@ function compareLastModifiedTime(stream, cb, sourceFile, targetPath) {
 	});
 }
 
-// only push through files with different SHA1 than the destination files
+/**
+ * Compare sha1 hex digest of source and target and only push through files which changed.
+ *
+ * @param {Stream} stream - Through stream object.
+ * @param {Function} cb - Done callback.
+ * @param {File} sourceFile - Vinyl file object.
+ * @param {string} targetPath - Path of the target.
+ * @return {undefined}
+ */
 function compareSha1Digest(stream, cb, sourceFile, targetPath) {
 	fs.readFile(targetPath, function (err, targetData) {
 		if (!fsOperationFailed(stream, sourceFile, err)) {
@@ -56,6 +90,23 @@ function compareSha1Digest(stream, cb, sourceFile, targetPath) {
 	});
 }
 
+/**
+ * Invocation method of the plugin.
+ *
+ * @param {Function|string} dest - The destination of the file, this can be one of:
+ *   1. A string which contains the same value as `gulp.dest` of this pipe receives.
+ *   2. A function which will get the through file object as first argument and has to return a string like 1. of this
+ *      list.
+ * @param {{
+ *   cwd: string
+ *   extension: string
+ *   hasChanged: Function
+ * }} [opts] - Plugin options:
+ *   - `cwd` is the current working directory to resolve paths, defaults to `process.cwd`.
+ *   - `extension` can be used to replace the source's extension if the destination file has a different one.
+ *   - `hasChanged` is the function to determine if a file has changed, defaults to `compareLastModified` of this plugin.
+ * @return {undefined}
+ */
 module.exports = function (dest, opts) {
 	if (!dest) {
 		throw new gutil.PluginError(pluginName, '`dest` required');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 'use strict';
+
+var pluginName = 'gulp-changed';
+
 var fs = require('fs');
 var path = require('path');
 var crypto = require('crypto');
@@ -9,7 +12,7 @@ var through = require('through2');
 function fsOperationFailed(stream, sourceFile, err) {
 	if (err) {
 		if (err.code !== 'ENOENT') {
-			stream.emit('error', new gutil.PluginError('gulp-changed', err, {
+			stream.emit('error', new gutil.PluginError(pluginName, err, {
 				fileName: sourceFile.path
 			}));
 		}
@@ -59,7 +62,7 @@ module.exports = function (dest, opts) {
 	opts.hasChanged = opts.hasChanged || compareLastModifiedTime;
 
 	if (!dest) {
-		throw new gutil.PluginError('gulp-changed', '`dest` required');
+		throw new gutil.PluginError(pluginName, '`dest` required');
 	}
 
 	return through.obj(function (file, enc, cb) {

--- a/index.js
+++ b/index.js
@@ -57,13 +57,13 @@ function compareSha1Digest(stream, cb, sourceFile, targetPath) {
 }
 
 module.exports = function (dest, opts) {
-	opts = opts || {};
-	opts.cwd = opts.cwd || process.cwd();
-	opts.hasChanged = opts.hasChanged || compareLastModifiedTime;
-
 	if (!dest) {
 		throw new gutil.PluginError(pluginName, '`dest` required');
 	}
+
+	opts = opts || {};
+	opts.cwd = opts.cwd || process.cwd();
+	opts.hasChanged = opts.hasChanged || compareLastModifiedTime;
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     {
       "name": "Milan Gardian",
       "url": "https://github.com/milang"
+    },
+    {
+      "name": "Richard Fussenegger",
+      "url": "https://github.com/Fleshgrinder"
     }
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
     "passthrough"
   ],
   "dependencies": {
+    "gulp": "^3.0.0",
     "gulp-util": "^3.0.0",
     "through2": "^0.6.1"
   },
   "devDependencies": {
     "concat-stream": "^1.4.6",
-    "gulp": "^3.0.0",
     "mocha": "*",
     "rimraf": "^2.2.6"
   }


### PR DESCRIPTION
This pull introduces an additional option called `pattern` which allows the caller to create a many-to-one matching. This is particularly useful in cases where files are aggregated, e.g. `foo.css` and `bar.css` result in `main.css`.

Note that this feature introduces a dependency on gulp itself, since its `src` method is used to apply the pattern.

I am not familiar with mocha and really lack the time to fiddle around with it. I tested it, but there may be edge cases. Feel free to reject this pull if missing unit tests are a total no-go. Although I'd love to see this feature in your module, as it would become *the* perfect addition to any task at hand during incremental builds. For instance, pairing many-to-one matching of this plugin with `gulp-cached` and `gulp-remember` allows one to build huge chains of files in no time.