### PR TITLE
Exposed fsOperationFailed for use in custom hasChanged.

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,5 +79,6 @@ module.exports = function (dest, opts) {
 	});
 };
 
+module.exports.fsOperationFailed = fsOperationFailed;
 module.exports.compareLastModifiedTime = compareLastModifiedTime;
 module.exports.compareSha1Digest = compareSha1Digest;


### PR DESCRIPTION
Because fsOperationFailed is used in both included comparisons, it seems reasonable to expose it for use in a consumer's custom hasChanged functions.