### PR TITLE
Adds SHA1 history feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ module.exports = function (dest, opts) {
 	opts.hasChanged = opts.hasChanged || (dest ? compareLastModifiedTime : compareSha1DigestHistory);
 
 	return through.obj(function (file, enc, cb) {
-		var dest2, newPath;
+		var dest2;
+		var newPath;
 
 		if (dest) {
 			dest2 = typeof dest === 'function' ? dest(file) : dest;

--- a/readme.md
+++ b/readme.md
@@ -48,11 +48,13 @@ This is needed to be able to compare the current files with the destination file
 
 Can also be a function returning a destination directory path.
 
+If destination is `null` or `undefined`, only the source file SHA1 history will be used to determine if the file has changed or not. Upon the first run, all files will be treated as changed.
+
 #### options
 
 ##### cwd
 
-Type: `string`  
+Type: `string`
 Default: `process.cwd()`
 
 The working directory the folder is relative to.
@@ -76,7 +78,7 @@ gulp.task('jade', function () {
 
 ##### hasChanged
 
-Type: `function`  
+Type: `function`
 Default: `changed.compareLastModifiedTime`
 
 Function that determines whether the source file is different from the destination file.

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ If destination is `null` or `undefined`, only the source file SHA1 history will 
 
 ##### cwd
 
-Type: `string`
+Type: `string`  
 Default: `process.cwd()`
 
 The working directory the folder is relative to.
@@ -78,7 +78,7 @@ gulp.task('jade', function () {
 
 ##### hasChanged
 
-Type: `function`
+Type: `function`  
 Default: `changed.compareLastModifiedTime`
 
 Function that determines whether the source file is different from the destination file.

--- a/test.js
+++ b/test.js
@@ -121,3 +121,35 @@ describe('compareSha1Digest', function () {
 			}));
 	});
 });
+
+describe('in-place file check', function () {
+	beforeEach(function () {
+		Object.keys(changed.shas).forEach(function (key) {
+			delete changed.shas[key];
+		});
+	});
+
+	it('passes all files on start', function (cb) {
+		gulp.src('fixture/different/src/*')
+			.pipe(changed())
+			.pipe(concatStream(function (buf) {
+				assert.equal(2, buf.length);
+				assert.equal('a', path.basename(buf[0].path));
+				assert.equal('b', path.basename(buf[1].path));
+				cb();
+			}));
+	});
+
+	it('should only pass through files when they change', function (cb) {
+		changed.shas[path.join(__dirname, 'fixture/different/src/a')] = 'not matching sha';
+		changed.shas[path.join(__dirname, 'fixture/different/src/b')] = 'e9d71f5ee7c92d6dc9e92ffdad17b8bd49418f98';
+
+		gulp.src('fixture/different/src/*')
+			.pipe(changed())
+			.pipe(concatStream(function (buf) {
+				assert.equal(1, buf.length);
+				assert.equal('a', path.basename(buf[0].path));
+				cb();
+			}));
+	});
+});


### PR DESCRIPTION
This PR allows `gulp-changed` to work only when the source file changes using SHA1 history. This is useful for things like in-place source formatting.