### PR TITLE
Fix stream bailing upon file deletion - fixes #37

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function sha1(buf) {
 function compareLastModifiedTime(stream, cb, sourceFile, targetPath) {
 	fs.stat(targetPath, function (err, targetStat) {
 		if (!fsOperationFailed(stream, sourceFile, err)) {
-			if (!sourceFile.stat || sourceFile.stat.mtime > targetStat.mtime) {
+			if (sourceFile.stat && sourceFile.stat.mtime > targetStat.mtime) {
 				stream.push(sourceFile);
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function sha1(buf) {
 function compareLastModifiedTime(stream, cb, sourceFile, targetPath) {
 	fs.stat(targetPath, function (err, targetStat) {
 		if (!fsOperationFailed(stream, sourceFile, err)) {
-			if (sourceFile.stat.mtime > targetStat.mtime) {
+			if (!sourceFile.stat || sourceFile.stat.mtime > targetStat.mtime) {
 				stream.push(sourceFile);
 			}
 		}


### PR DESCRIPTION
Addresses issue where stream bails on file deletion (an error that is not caught by plumber()) as proposed by @ccheever