### PR TITLE
Do not attempt comparing SHA1 for directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,15 @@ function compareLastModifiedTime(stream, sourceFile, targetPath) {
 
 // Only push through files with different contents than the destination files
 function compareContents(stream, sourceFile, targetPath) {
-	return readFile(targetPath)
+	return stat(targetPath)
+		.then(targetStat => {
+			if (!targetStat.isFile()) {
+				return;
+			}
+			return readFile(targetPath);
+		})
 		.then(targetData => {
-			if (sourceFile.isNull() || !sourceFile.contents.equals(targetData)) {
+			if (sourceFile.isNull() || (targetData && !sourceFile.contents.equals(targetData))) {
 				stream.push(sourceFile);
 			}
 		});


### PR DESCRIPTION
`compareSha1Digest` does not check whether `sourceFile` represents a directory, which can happen for example when using glob patterns for `src`. This PR makes sure only files are processed; at the moment if the source paths contain a directory the following error is thrown:

```
(node:9418) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error in plugin 'gulp-changed'
Message:
    EISDIR: illegal operation on a directory, read
Details:
    errno: -21
    code: EISDIR
    syscall: read
    fileName: [directory path]
```