### PR TITLE
Fix `compareLastModifiedTime` for Node.js 14.17.0 (#83)

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ async function compareLastModifiedTime(stream, sourceFile, targetPath) {
 	// TODO: Use the `stat` `bigint` option when targeting Node.js 10 and Gulp supports it
 	const targetStat = await stat(targetPath);
 
-	if (sourceFile.stat && Math.floor(sourceFile.stat.mtimeMs) > Math.floor(targetStat.mtimeMs)) {
+	if (sourceFile.stat && Math.floor(sourceFile.stat.mtimeMs) > Math.ceil(targetStat.mtimeMs)) {
 		stream.push(sourceFile);
 	}
 }

--- a/index.js
+++ b/index.js
@@ -25,15 +25,9 @@ async function compareLastModifiedTime(stream, sourceFile, targetPath) {
 	// TODO: Use the `stat` `bigint` option when targeting Node.js 10 and Gulp supports it
 	const targetStat = await stat(targetPath);
 
-	// Precision is lost in the mtime when gulp copies the file from source to target
-	// so we cannot compare the mtimes directly. This has been the case since gulp 4.0.
-	// Now, due to an issue in libuv affecting node 14.17.0 and above (including 16.x -
-	// see https://github.com/nodejs/node/issues/38981) when gulp copies the file to the
-	// target its mtime may be behind the source file by up to 1ms. eg if the source
-	// file has an mtime like 1623259049896.314 the target file mtime can end up as
-	// 1623259049895.999. So to compare safely we use floor on the source and ceil
-	// on the target, which would give us 1623259049896 for both source and target in
-	// that example case.
+	/*
+	Precision is lost in the `mtime` when Gulp copies the file from source to target so we cannot compare the modified times directly. This has been the case since Gulp 4. Now, due to an issue in libuv affecting Node.js 14.17.0 and above (including 16.x: https://github.com/nodejs/node/issues/38981) when Gulp copies the file to the target, its `mtime` may be behind the source file by up to 1ms. For example, if the source file has a `mtime` like `1623259049896.314`, the target file `mtime` can end up as `1623259049895.999`. So to compare safely we use floor on the source and ceil on the target, which would give us `1623259049896` for both source and target in that example case.
+	*/
 	if (sourceFile.stat && Math.floor(sourceFile.stat.mtimeMs) > Math.ceil(targetStat.mtimeMs)) {
 		stream.push(sourceFile);
 	}

--- a/test.js
+++ b/test.js
@@ -36,7 +36,7 @@ const macro = async (t, options) => {
 
 		stream.on('data', file => {
 			files.push(file);
-			fs.writeFileSync(path.join(dest, file.relative), file);
+			fs.writeFileSync(path.join(dest, file.relative), file.contents);
 		});
 
 		stream.on('end', () => {


### PR DESCRIPTION
This work-around resolves the problem reported in https://github.com/sindresorhus/gulp-changed/issues/83