### PR TITLE
GH-87 Track gulp-plugin-extras as a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 	],
 	"dependencies": {
 		"change-file-extension": "^0.1.0",
+		"gulp-plugin-extras": "^0.3.0",
 		"touch": "^3.1.0"
 	},
 	"devDependencies": {
@@ -48,7 +49,6 @@
 		"figures": "^6.0.1",
 		"get-stream": "^8.0.1",
 		"gulp": "^4.0.2",
-		"gulp-plugin-extras": "^0.3.0",
 		"vinyl": "^3.0.0",
 		"xo": "^0.56.0"
 	},


### PR DESCRIPTION
## Description

This PR tracks `gulp-plugin-extras` as a regular dependency instead of a dev dependency.

I think tests could not have caught this bug because the testing job in GH Actions installs all dependencies (i.e. not just regular dependencies). This is necessary in order to install testing utilities, so I’m not sure how to guard/protect against this kind of bug in the future. Happy to make adjustments to this PR if you have any ideas on how to protect against this.

## Motivation

When `gulp-changed` is installed in downstream projects, dev dependencies are ignored, resulting in failed builds when `gulp-changed` attempts to import `gulp-plugin-extras`, since the latter is currently tracked as a dev dependency.

Closes #87.